### PR TITLE
test: seed beta manifest for channel verification

### DIFF
--- a/manifests/latest-beta.json
+++ b/manifests/latest-beta.json
@@ -1,0 +1,14 @@
+{
+  "version": "v1.3.12-beta.1",
+  "pub_date": "2026-04-18T12:00:00Z",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVRN2dDSkh1U3VYT2w0VzVsL1RDdEh3WUdacEdXSTR3VG5GM2t1eVhvSG1ua2FvR1ZXSk0raHg3Rmc5MUwwTjRmdmYwZTR4L1VYRmZpcDNzMExNRXp1bHZLQnMrUGJSRUFvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc2NDkwMTI4CWZpbGU6TWFya1ZpZXdlcl91bml2ZXJzYWwuYXBwLnRhci5negpBT2N5TWxFcWlZRysxWE56SkZaOUlyZE5IMnFnVE1heGQ0czZ1Mk1STXRuNGJSUHZPUnpidEdxcmd6OUdZaVlwdjhuaHg0USt3ay9IeHZoSzNhbndCdz09Cg==",
+      "url": "https://github.com/SeungbinBaik/markviewer-releases/releases/download/v1.3.11/MarkViewer_universal.app.tar.gz"
+    },
+    "darwin-x86_64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVRN2dDSkh1U3VYT2w0VzVsL1RDdEh3WUdacEdXSTR3VG5GM2t1eVhvSG1ua2FvR1ZXSk0raHg3Rmc5MUwwTjRmdmYwZTR4L1VYRmZpcDNzMExNRXp1bHZLQnMrUGJSRUFvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc2NDkwMTI4CWZpbGU6TWFya1ZpZXdlcl91bml2ZXJzYWwuYXBwLnRhci5negpBT2N5TWxFcWlZRysxWE56SkZaOUlyZE5IMnFnVE1heGQ0czZ1Mk1STXRuNGJSUHZPUnpidEdxcmd6OUdZaVlwdjhuaHg0USt3ay9IeHZoSzNhbndCdz09Cg==",
+      "url": "https://github.com/SeungbinBaik/markviewer-releases/releases/download/v1.3.11/MarkViewer_universal.app.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Phase 1 opt-in beta channel wiring (in `immarkviewer`) needs one end-to-end verification pass before build/rollback workflows are in place.
- Seeds `manifests/latest-beta.json` pointing at the existing v1.3.11 DMG asset so the renderer's beta endpoint (`raw.githubusercontent.com/.../main/manifests/latest-beta.json`) returns a real manifest.
- `version` field is bumped to `v1.3.12-beta.1` so the updater reports "update available"; `signature` + `url` match the v1.3.11 bundle (no forged content — just the same bundle labelled with a new version for this one-shot test).

## Scope

- Zero impact on current users (production v1.3.11 has no beta endpoint in code yet).
- `latest.json` is not modified, `releases/latest/` redirect is unchanged.
- Will be reverted by a follow-up PR immediately after the manual verification pass.

## Test plan

- [ ] Merge this PR
- [ ] Toggle Settings → Early Access Updates in local dev build
- [ ] Relaunch app or invoke `tauriAPI.checkForUpdates(false, 'beta')`
- [ ] Confirm `update-available` event fires and UpdateModal shows `[BETA]` badge + warning line
- [ ] Revert via follow-up PR before closing the verification session