### PR TITLE
feat(workflows): add beta channel support + rollback-beta

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,24 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., 1.0.26)'
+        description: 'Version to build (e.g., 1.0.26 or 1.0.26-beta.1)'
         required: true
         type: string
+      channel:
+        description: 'Release channel'
+        required: false
+        default: 'stable'
+        type: choice
+        options:
+          - stable
+          - beta
 
 jobs:
   build-macos:
     runs-on: self-hosted
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
+      channel: ${{ steps.version.outputs.CHANNEL }}
 
     steps:
-      - name: Get version
+      - name: Get version and channel
         id: version
         run: |
           if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
             echo "VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+            PAYLOAD_CHANNEL="${{ github.event.client_payload.channel }}"
+            echo "CHANNEL=${PAYLOAD_CHANNEL:-stable}" >> $GITHUB_OUTPUT
           else
             echo "VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            INPUT_CHANNEL="${{ inputs.channel }}"
+            echo "CHANNEL=${INPUT_CHANNEL:-stable}" >> $GITHUB_OUTPUT
           fi
 
       - name: Clean workspace
@@ -201,20 +214,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.version.outputs.CHANNEL }}" == "beta" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
           gh release create v${{ steps.version.outputs.VERSION }} \
             --repo SeungbinBaik/markviewer-releases \
             --title "MarkViewer v${{ steps.version.outputs.VERSION }}" \
             --notes "Release v${{ steps.version.outputs.VERSION }}" \
+            $PRERELEASE_FLAG \
             MarkViewer.dmg \
             MarkViewer_universal.app.tar.gz \
             MarkViewer_universal.app.tar.gz.sig
 
-      - name: Update manifest
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+      - name: Generate manifest JSON
+        id: manifest
         run: |
-          # Create latest.json with update information
-          cat > latest.json <<EOF
+          cat > generated-manifest.json <<EOF
           {
             "version": "v${{ steps.version.outputs.VERSION }}",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
@@ -231,10 +248,63 @@ jobs:
           }
           EOF
 
+      - name: Upload latest.json (stable only)
+        if: steps.version.outputs.CHANNEL == 'stable'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          cp generated-manifest.json latest.json
           gh release upload v${{ steps.version.outputs.VERSION }} \
             --repo SeungbinBaik/markviewer-releases \
             --clobber \
             latest.json
+
+      - name: Checkout markviewer-releases for manifest sync
+        uses: actions/checkout@v4
+        with:
+          repository: SeungbinBaik/markviewer-releases
+          ref: main
+          path: releases-repo
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Sync manifests/latest-beta.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          cd releases-repo
+          mkdir -p manifests
+          cp ../generated-manifest.json manifests/latest-beta.json
+
+          # Stable sync integrity: the just-written manifests/latest-beta.json
+          # must be byte-for-byte equal to the latest.json release asset so
+          # beta users naturally rejoin stable on the next check. Abort on
+          # mismatch rather than risk publishing inconsistent state.
+          if [ "${{ steps.version.outputs.CHANNEL }}" == "stable" ]; then
+            diff -q ../latest.json manifests/latest-beta.json || {
+              echo "::error::latest.json and manifests/latest-beta.json differ byte-level on stable sync";
+              exit 1;
+            }
+          fi
+
+          # URL sanity: the manifest's DMG url must point to this tag's
+          # release assets. This guards against a beta-tag URL leaking into
+          # a stable sync or vice versa.
+          jq -e --arg tag "v${{ steps.version.outputs.VERSION }}" \
+            '.platforms | to_entries[] | .value.url | contains("/releases/download/" + $tag + "/")' \
+            manifests/latest-beta.json > /dev/null || {
+            echo "::error::manifests/latest-beta.json URL does not point to v${{ steps.version.outputs.VERSION }} release assets";
+            exit 1;
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifests/latest-beta.json
+          if git diff --cached --quiet; then
+            echo "manifests/latest-beta.json unchanged, skipping commit"
+            exit 0
+          fi
+          git commit -m "chore(manifest): sync latest-beta.json for v${{ steps.version.outputs.VERSION }} (${{ steps.version.outputs.CHANNEL }})"
+          git push origin main
 
       - name: Clean up
         if: always()
@@ -245,6 +315,7 @@ jobs:
 
   update-website:
     needs: build-macos
+    if: needs.build-macos.outputs.channel != 'beta'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rollback-beta.yml
+++ b/.github/workflows/rollback-beta.yml
@@ -1,0 +1,56 @@
+name: Rollback Beta Manifest
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Either a commit SHA on main whose manifests/latest-beta.json to restore, OR the literal "stable" to make latest-beta byte-for-byte equal to the current latest.json'
+        required: true
+        type: string
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout markviewer-releases
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Restore manifests/latest-beta.json
+        run: |
+          TARGET="${{ inputs.target }}"
+          mkdir -p manifests
+
+          if [ "$TARGET" == "stable" ]; then
+            # Mirror current stable latest.json so beta clients rejoin stable
+            # on the next check. latest.json itself is not touched.
+            curl -fsSL -o /tmp/stable-latest.json \
+              https://github.com/SeungbinBaik/markviewer-releases/releases/latest/download/latest.json
+            cp /tmp/stable-latest.json manifests/latest-beta.json
+          else
+            # Restore content from the given commit SHA on main.
+            git show "$TARGET:manifests/latest-beta.json" > /tmp/target-manifest.json
+            cp /tmp/target-manifest.json manifests/latest-beta.json
+          fi
+
+      - name: Verify restored manifest is valid JSON with platforms
+        run: |
+          jq -e '.version and .platforms["darwin-aarch64"].url and .platforms["darwin-x86_64"].url' \
+            manifests/latest-beta.json > /dev/null || {
+            echo "::error::restored manifests/latest-beta.json is not a valid updater manifest";
+            exit 1;
+          }
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifests/latest-beta.json
+          if git diff --cached --quiet; then
+            echo "manifests/latest-beta.json already at requested target; no commit"
+            exit 0
+          fi
+          git commit -m "chore(manifest): rollback latest-beta.json (target=${{ inputs.target }})"
+          git push origin main


### PR DESCRIPTION
## Summary

Phase 1 opt-in beta channel needs two workflow changes before the first real beta release (Rollout Step 3):

1. **`build-macos.yml`** — accept a `channel` input and branch on stable/beta, keeping the two channels physically separated:
   - Stable continues to publish `latest.json` as a release asset (existing `/releases/latest/` redirect path; beta pre-releases are auto-skipped by that redirect).
   - Beta marks the GitHub Release as `--prerelease` and only writes `manifests/latest-beta.json` to `main`.
   - Stable path asserts `latest.json` and `manifests/latest-beta.json` are **byte-for-byte equal** (`diff -q`) and that the DMG url points to the new stable tag (`jq contains`). Aborts the workflow on mismatch — no silent beta-asset contamination of stable.
   - `update-website` job is gated on `channel != 'beta'` so the marketing site's JSON-LD `softwareVersion` stays on the latest stable number.
2. **`rollback-beta.yml`** (new) — manual rollback path that rewrites only `manifests/latest-beta.json`, either from a given SHA or by mirroring the current `latest.json` (`target=stable`). `latest.json` and every release asset are untouched, so a bad beta can be reversed in seconds without cutting a new stable release.

## Scope / safety

- Stable releases: behavior is preserved plus one new Actions commit to `main` each release that keeps `manifests/latest-beta.json == latest.json`. This keeps beta users on the same version as stable between beta cuts.
- Beta releases: new `--prerelease` marking is the safety net — the stable `/releases/latest/` redirect ignores pre-releases, so stable clients never see beta even if the Actions bot mis-routes a file.
- Current users (Phase 1 not yet shipped): zero impact. `latest.json` redirect unchanged, beta endpoint not yet consumed by any shipped app.

## Prerequisites for the first beta cut

- `secrets.RELEASE_PAT` already has `contents: write` on this repo (used by the existing stable flow). Same token handles the new commit step — no secret changes needed.
- Consider adding a CODEOWNERS entry for `manifests/` and a branch-protection rule allowing only the `github-actions[bot]` to push to that path (Safety Invariant #2). Can be done in a follow-up; not blocking this PR.

## Test plan

- [ ] Merge this PR (no workflow actually runs on merge; both workflows are `workflow_dispatch` only)
- [ ] Trigger a stable dry-run if a test version is available: confirm latest.json asset is uploaded **and** a new commit appears on `main` writing `manifests/latest-beta.json` identical to it
- [ ] Trigger a beta dry-run for `vX.Y.Z-beta.1`: confirm GitHub Release is marked Pre-release, DMG + sig + tar.gz uploaded to that tag, only `manifests/latest-beta.json` changes on `main`, `latest.json` untouched, `update-website` job is skipped
- [ ] Trigger `rollback-beta.yml` with `target=stable`: confirm `manifests/latest-beta.json` becomes byte-for-byte equal to `latest.json`, no release asset changes