### PR TITLE
chore(ci): bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -260,7 +260,7 @@ jobs:
             latest.json
 
       - name: Checkout markviewer-releases for manifest sync
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: SeungbinBaik/markviewer-releases
           ref: main
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: SeungbinBaik/markviewer
           token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/rollback-beta.yml
+++ b/.github/workflows/rollback-beta.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout markviewer-releases
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary

Bump `actions/checkout` from `@v4` to `@v5` in both workflows. `v5` is the maintainer's Node 24 compatible release; `v4` still runs on Node 20 which GitHub Actions will stop supporting.

GitHub's deprecation timeline:
- **2026-06-02**: Node 24 forced as default on runners
- **2026-09-16**: Node 20 fully removed

Three usages updated across two files:
- `build-macos.yml` — repo checkout for manifest sync
- `build-macos.yml` — website repo checkout for JSON-LD version bump
- `rollback-beta.yml` — repo checkout for manifest rollback

Other actions are referenced by tag (e.g. `dtolnay/rust-toolchain@stable`) so they'll pick up Node 24 from upstream automatically.

## Test plan

- [ ] Next beta deploy (already triggered for v1.3.13-beta.4 at time of this PR creation) completes without the deprecation warning in the Actions log.
- [ ] Manifests sync as before, release is marked pre-release.
- [ ] Rollback workflow path can still be dispatched (no need to actually run it now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)